### PR TITLE
1

### DIFF
--- a/elsaserver/__init__.py
+++ b/elsaserver/__init__.py
@@ -30,6 +30,7 @@ from elsaserver.api.get_author_trend import get_author_trend
 from elsaserver.api.get_author_keywords import get_author_keywords
 from elsaserver.api.get_author_jmetrics import get_author_jmetrics
 from elsaserver.api.get_author_network import get_author_network
+from elsaserver.api.get_author_stats import get_author_stats
 
 
 # ==============================================================================
@@ -43,6 +44,7 @@ with io.open(CURRENT_DIR / 'config.json', 'r') as config_file:
 config = config['api']
 
 HOME_INSTITUTION_ID_SCP = config['home_institution_id_scp']
+HOME_COUNTRY_DOMAIN = config['home_country_domain']
 YEAR_RANGE = config['year_range']
 KEYWORDS_THRESHOLD = config['keywords_threshold']
 COLLABORATION_THRESHOLD = config['collaboration_threshold']
@@ -59,6 +61,10 @@ session = Session()
 home_institution = session \
     .query(Institution) \
     .filter(Institution.id_scp == HOME_INSTITUTION_ID_SCP) \
+    .first()
+home_country = session \
+    .query(Country) \
+    .filter(Country.domain == HOME_COUNTRY_DOMAIN) \
     .first()
 
 authors_backend, authors_frontend = get_institution_authors(

--- a/elsaserver/__init__.py
+++ b/elsaserver/__init__.py
@@ -1,23 +1,32 @@
-import io
-import json
-from pathlib import Path
+from elsaserver.definitions import \
+    Session, \
+    Author_Department, \
+    Paper_Keyword, \
+    Paper_Author, \
+    Source_Subject, \
+    Author, \
+    Author_Profile, \
+    Country, \
+    Department, \
+    Fund, \
+    Institution, \
+    Keyword, \
+    Paper, \
+    Source, \
+    Source_Metric, \
+    Subject, \
+    home_country, \
+    home_institution, \
+    authors_backend, \
+    authors_frontend, \
+    HOME_INSTITUTION_ID_SCP, \
+    HOME_COUNTRY_DOMAIN, \
+    YEAR_RANGE, \
+    KEYWORDS_THRESHOLD, \
+    COLLABORATION_THRESHOLD, \
+    NETWORK_MAX_COUNT, \
+    INITIAL_RESPONSE
 
-from elsametric.models.base import Session
-from elsametric.models.associations import Author_Department
-from elsametric.models.associations import Paper_Keyword
-from elsametric.models.associations import Paper_Author
-from elsametric.models.associations import Source_Subject
-from elsametric.models.author import Author
-from elsametric.models.author_profile import Author_Profile
-from elsametric.models.country import Country
-from elsametric.models.department import Department
-from elsametric.models.fund import Fund
-from elsametric.models.institution import Institution
-from elsametric.models.keyword_ import Keyword
-from elsametric.models.paper import Paper
-from elsametric.models.source import Source
-from elsametric.models.source_metric import Source_Metric
-from elsametric.models.subject import Subject
 
 from elsaserver.api.get_institution_authors import get_institution_authors
 from elsaserver.api.get_author_info import get_author_info
@@ -32,50 +41,4 @@ from elsaserver.api.get_author_jmetrics import get_author_jmetrics
 from elsaserver.api.get_author_network import get_author_network
 from elsaserver.api.get_author_stats import get_author_stats
 
-
-# ==============================================================================
-# Config
-# ==============================================================================
-
-
-CURRENT_DIR = Path.cwd()
-with io.open(CURRENT_DIR / 'config.json', 'r') as config_file:
-    config = json.load(config_file)
-config = config['api']
-
-HOME_INSTITUTION_ID_SCP = config['home_institution_id_scp']
-HOME_COUNTRY_DOMAIN = config['home_country_domain']
-YEAR_RANGE = config['year_range']
-KEYWORDS_THRESHOLD = config['keywords_threshold']
-COLLABORATION_THRESHOLD = config['collaboration_threshold']
-NETWORK_MAX_COUNT = config['network_max_count']
-INITIAL_RESPONSE = {'message': 'not found', 'code': 404}
-
-
-# ==============================================================================
-# Functions & Variables
-# ==============================================================================
-
-
-session = Session()
-home_institution = session \
-    .query(Institution) \
-    .filter(Institution.id_scp == HOME_INSTITUTION_ID_SCP) \
-    .first()
-home_country = session \
-    .query(Country) \
-    .filter(Country.domain == HOME_COUNTRY_DOMAIN) \
-    .first()
-
-authors_backend, authors_frontend = get_institution_authors(
-    session, HOME_INSTITUTION_ID_SCP)
-
-
-def front_back_mapper(id_frontend: str):
-    if not isinstance(id_frontend, str):
-        return None
-
-    try:
-        return authors_backend[id_frontend]
-    except KeyError:
-        return None
+from elsaserver.helpers import front_back_mapper

--- a/elsaserver/api/get_author_stats.py
+++ b/elsaserver/api/get_author_stats.py
@@ -3,7 +3,24 @@ from datetime import datetime
 from elsametric.models.author import Author
 from elsametric.models.country import Country
 
-# from .. import home_country
+from .. import home_country, home_institution
+
+paper_types_mapper = {
+    'ar': 'article',
+    'ip': 'article',
+    'cp': 'conference',
+    're': 'review',
+    'bk': 'book',
+    'ch': 'book',
+    'tb': 'retracted',
+    'le': 'other',
+    'ed': 'other',
+    'no': 'note',
+    'er': 'other',
+    'sh': 'other',
+    'ab': 'other',
+    'na': 'other'
+}
 
 
 def get_author_stats(session, id_backend: int):
@@ -11,20 +28,24 @@ def get_author_stats(session, id_backend: int):
     stats = {
         'hIndex': None,
         'i10Index': None,
-        'totalPapers': None,
-        'totalCitationss': None,
-        'thisYearPapers': None,
-        'thisYearCitationss': None,
-        'intl_collaborations': None,
+        'papers': {
+            'totalPapers': None,
+            'totalCitationss': None,
+            'thisYearPapers': None,
+            'thisYearCitationss': None
+        },
+        'paperTypes': {},
+        'collaborations': {
+            'singleAuthorship': None,
+            'instCollaborations': None,
+            'natCollaborations': None,
+            'intlCollaborations': None
+        }
     }
-
-    home_country = session \
-        .query(Country) \
-        .filter(Country.domain == 'IR') \
-        .first()
 
     try:
         author = session.query(Author).get(id_backend)  # None if not found
+        this_year = datetime.now().year
 
         stats['hIndex'] = {
             'value': author.h_index_gsc,  # possible AttributeError
@@ -35,30 +56,61 @@ def get_author_stats(session, id_backend: int):
             'retrievalTime': author.retrieval_time_gsc,
         }
 
-        papers_trend = author.get_papers()
-        citations_trend = author.get_citations()
-        this_year = datetime.now().year
+        total_citations = this_year_papers = this_year_citations = 0
+        single_authorship = inst_collaborations = 0
+        nat_collaborations = intl_collaborations = 0
 
-        stats['totalPapers'] = {'value': sum(papers_trend.values())}
-        stats['totalCitationss'] = {'value': sum(citations_trend.values())}
-        if this_year in papers_trend.keys():
-            stats['thisYearPapers'] = {'value': papers_trend[this_year]}
-            stats['thisYearCitationss'] = {'value': citations_trend[this_year]}
-
-        intl_collaborations = 0
         papers = [paper_author.paper for paper_author in author.papers]
+        stats['papers']['totalPapers'] = len(papers)
         for paper in papers:
+            # papers & citations count
+            if paper.get_year() == this_year:
+                this_year_papers += 1
+                this_year_citations += paper.cited_cnt or 0
+            total_citations += paper.cited_cnt or 0
+
+            # paper types
+            paper_type = paper_types_mapper[paper.type]
+            try:
+                stats['paperTypes'][paper_type] += 1
+            except KeyError:
+                stats['paperTypes'][paper_type] = 1
+
             co_authors = [
                 paper_author.author for paper_author in paper.authors]
+            if len(co_authors) == 1:
+                single_authorship += 1
+                continue
+            is_intl_paper = is_nat_paper = False
             for co_author in co_authors:
-                if co_author == author:
+                if co_author == author:  # skipping the main author
                     continue
 
-                countries = co_author.get_countries()
-                if countries and home_country not in countries:
-                    intl_collaborations += 1
+                # Since multiple SQLAlchemy sessions might be involved (between
+                # 'home_country', 'home_institution', and 'co_author' objects),
+                # it's best to use the objects' ids in comparisons.
+                country_ids = {c.id for c in co_author.get_countries()}
+                if country_ids and home_country.id not in country_ids:
+                    is_intl_paper = True
                     break
-        stats['intl_collaborations'] = intl_collaborations
+                institution_ids = {i.id for i in co_author.get_institutions()}
+                if home_institution.id not in institution_ids:
+                    is_nat_paper = True
+
+            if is_intl_paper:
+                intl_collaborations += 1
+            elif is_nat_paper:
+                nat_collaborations += 1
+            else:
+                inst_collaborations += 1
+
+        stats['papers']['totalCitationss'] = total_citations
+        stats['papers']['thisYearPapers'] = this_year_papers
+        stats['papers']['thisYearCitationss'] = this_year_citations
+        stats['collaborations']['singleAuthorship'] = single_authorship
+        stats['collaborations']['instCollaborations'] = inst_collaborations
+        stats['collaborations']['natCollaborations'] = nat_collaborations
+        stats['collaborations']['intlCollaborations'] = intl_collaborations
 
         response = stats
     except AttributeError:

--- a/elsaserver/api/get_author_stats.py
+++ b/elsaserver/api/get_author_stats.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+
+from elsametric.models.author import Author
+from elsametric.models.country import Country
+
+# from .. import home_country
+
+
+def get_author_stats(session, id_backend: int):
+    response = None
+    stats = {
+        'hIndex': None,
+        'i10Index': None,
+        'totalPapers': None,
+        'totalCitationss': None,
+        'thisYearPapers': None,
+        'thisYearCitationss': None,
+        'intl_collaborations': None,
+    }
+
+    home_country = session \
+        .query(Country) \
+        .filter(Country.domain == 'IR') \
+        .first()
+
+    try:
+        author = session.query(Author).get(id_backend)  # None if not found
+
+        stats['hIndex'] = {
+            'value': author.h_index_gsc,  # possible AttributeError
+            'retrievalTime': author.retrieval_time_gsc,
+        }
+        stats['i10Index'] = {
+            'value': author.i10_index_gsc,
+            'retrievalTime': author.retrieval_time_gsc,
+        }
+
+        papers_trend = author.get_papers()
+        citations_trend = author.get_citations()
+        this_year = datetime.now().year
+
+        stats['totalPapers'] = {'value': sum(papers_trend.values())}
+        stats['totalCitationss'] = {'value': sum(citations_trend.values())}
+        if this_year in papers_trend.keys():
+            stats['thisYearPapers'] = {'value': papers_trend[this_year]}
+            stats['thisYearCitationss'] = {'value': citations_trend[this_year]}
+
+        intl_collaborations = 0
+        papers = [paper_author.paper for paper_author in author.papers]
+        for paper in papers:
+            co_authors = [
+                paper_author.author for paper_author in paper.authors]
+            for co_author in co_authors:
+                if co_author == author:
+                    continue
+
+                countries = co_author.get_countries()
+                if countries and home_country not in countries:
+                    intl_collaborations += 1
+                    break
+        stats['intl_collaborations'] = intl_collaborations
+
+        response = stats
+    except AttributeError:
+        pass
+
+    return response

--- a/elsaserver/api/get_authors_rank.py
+++ b/elsaserver/api/get_authors_rank.py
@@ -1,6 +1,7 @@
 from elsametric.models.author import Author
 
-from .. import authors_backend
+from .. import authors_backend, home_institution, home_country
+
 
 def get_authors_rank(session):
     stats = {
@@ -8,18 +9,42 @@ def get_authors_rank(session):
         'i10_index_gsc': [],
         'total_papers': [],
         'total_citations': [],
+        'this_year_papers': [],
+        'this_year_citations': [],
+        'intl_collaborations': [],
     }
 
     for id_backend in authors_backend.values():
         try:
             author = session.query(Author).get(id_backend)  # None if not found
+
             # possible AttributeError
             stats['h_index_gsc'].append(author.h_index_gsc)
             stats['i10_index_gsc'].append(author.i10_index_gsc)
+
             # possible TypeError
-            stats['total_papers'].append(sum(author.get_papers().values()))
-            stats['total_citations'].append(
-                sum(author.get_citations().values()))
+            papers_trend = author.get_papers()
+            citations_trend = author.get_citations()
+            stats['total_papers'].append(sum(papers_trend.values()))
+            stats['total_citations'].append(sum(citations_trend.values()))
+
+            this_year = max(papers_trend.keys())
+            stats['this_year_papers'].append(papers_trend[this_year])
+            stats['this_year_citations'].append(citations_trend[this_year])
+
+            intl_collaborations = 0
+            papers = [paper_author.paper for paper_author in author.papers]
+            for paper in papers:
+                co_authors = [
+                    paper_author.author for paper_author in paper.authors]
+                for co_author in co_authors:
+                    if co_author == author:
+                        continue
+                    countries = co_author.get_countries()
+                    if countries and home_country not in countries:
+                        intl_collaborations += 1
+                        break
+            stats['intl_collaborations'].append(intl_collaborations)
         except (AttributeError, TypeError) as e:
             print(e)
             pass

--- a/elsaserver/api/get_authors_rank.py
+++ b/elsaserver/api/get_authors_rank.py
@@ -1,0 +1,27 @@
+from elsametric.models.author import Author
+
+from .. import authors_backend
+
+def get_authors_rank(session):
+    stats = {
+        'h_index_gsc': [],
+        'i10_index_gsc': [],
+        'total_papers': [],
+        'total_citations': [],
+    }
+
+    for id_backend in authors_backend.values():
+        try:
+            author = session.query(Author).get(id_backend)  # None if not found
+            # possible AttributeError
+            stats['h_index_gsc'].append(author.h_index_gsc)
+            stats['i10_index_gsc'].append(author.i10_index_gsc)
+            # possible TypeError
+            stats['total_papers'].append(sum(author.get_papers().values()))
+            stats['total_citations'].append(
+                sum(author.get_citations().values()))
+        except (AttributeError, TypeError) as e:
+            print(e)
+            pass
+
+    return stats

--- a/elsaserver/definitions.py
+++ b/elsaserver/definitions.py
@@ -1,0 +1,60 @@
+import io
+import json
+from pathlib import Path
+
+from elsametric.models.base import Session
+from elsametric.models.associations import Author_Department
+from elsametric.models.associations import Paper_Keyword
+from elsametric.models.associations import Paper_Author
+from elsametric.models.associations import Source_Subject
+from elsametric.models.author import Author
+from elsametric.models.author_profile import Author_Profile
+from elsametric.models.country import Country
+from elsametric.models.department import Department
+from elsametric.models.fund import Fund
+from elsametric.models.institution import Institution
+from elsametric.models.keyword_ import Keyword
+from elsametric.models.paper import Paper
+from elsametric.models.source import Source
+from elsametric.models.source_metric import Source_Metric
+from elsametric.models.subject import Subject
+
+from elsaserver.api.get_institution_authors import get_institution_authors
+
+
+# ==============================================================================
+# Config
+# ==============================================================================
+
+
+CURRENT_DIR = Path.cwd()
+with io.open(CURRENT_DIR / 'config.json', 'r') as config_file:
+    config = json.load(config_file)
+config = config['api']
+
+HOME_INSTITUTION_ID_SCP = config['home_institution_id_scp']
+HOME_COUNTRY_DOMAIN = config['home_country_domain']
+YEAR_RANGE = config['year_range']
+KEYWORDS_THRESHOLD = config['keywords_threshold']
+COLLABORATION_THRESHOLD = config['collaboration_threshold']
+NETWORK_MAX_COUNT = config['network_max_count']
+INITIAL_RESPONSE = {'message': 'not found', 'code': 404}
+
+
+# ==============================================================================
+# Functions & Variables
+# ==============================================================================
+
+
+session = Session()
+home_country = session \
+    .query(Country) \
+    .filter(Country.domain == HOME_COUNTRY_DOMAIN) \
+    .first()
+home_institution = session \
+    .query(Institution) \
+    .filter(Institution.id_scp == HOME_INSTITUTION_ID_SCP) \
+    .first()
+
+authors_backend, authors_frontend = get_institution_authors(
+    session, HOME_INSTITUTION_ID_SCP)

--- a/elsaserver/helpers.py
+++ b/elsaserver/helpers.py
@@ -1,3 +1,4 @@
+from elsaserver import authors_backend
 
 
 def author_formatter(author, department: bool = False,
@@ -132,3 +133,13 @@ def get_joint_papers(papers: list, co_author, format_results: bool = False):
         joint_papers = [paper_formatter(paper) for paper in joint_papers]
 
     return joint_papers
+
+
+def front_back_mapper(id_frontend: str):
+    if not isinstance(id_frontend, str):
+        return None
+
+    try:
+        return authors_backend[id_frontend]
+    except KeyError:
+        return None

--- a/main.py
+++ b/main.py
@@ -19,8 +19,9 @@ from elsaserver import \
     get_author_trend, \
     get_author_keywords, \
     get_author_jmetrics, \
-    get_author_network
-from elsaserver.api.get_authors_rank import get_authors_rank
+    get_author_network, \
+    get_author_stats
+# from elsaserver.api.get_authors_rank import get_authors_rank
 
 from elsametric.models.base import Session
 
@@ -43,9 +44,9 @@ async def authors_list():
     return authors_frontend
 
 
-@app.get('/a/rankings')
-async def authors_rankings():
-    return get_authors_rank(session)
+# @app.get('/a/rankings')
+# async def authors_rankings():
+#     return get_authors_rank(session)
 
 
 @app.get('/a/{id_frontend}')
@@ -99,6 +100,12 @@ async def author_network(id_frontend: str):
     return get_author_network(
         session, id_backend, collaboration_threshold=COLLABORATION_THRESHOLD,
         network_max_count=NETWORK_MAX_COUNT)
+
+
+@app.get('/a/{id_frontend}/stats')
+async def author_stats(id_frontend: str):
+    id_backend = front_back_mapper(id_frontend)
+    return get_author_stats(session, id_backend)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from elsaserver import \
     get_author_keywords, \
     get_author_jmetrics, \
     get_author_network
+from elsaserver.api.get_authors_rank import get_authors_rank
 
 from elsametric.models.base import Session
 
@@ -40,6 +41,11 @@ async def authors():
 @app.get('/a/list')
 async def authors_list():
     return authors_frontend
+
+
+@app.get('/a/rankings')
+async def authors_rankings():
+    return get_authors_rank(session)
 
 
 @app.get('/a/{id_frontend}')


### PR DESCRIPTION
Closes #1 

**Important notes:**

- This merge does not cover any _rankings_ or _histogram_ functionality. Those should be approached in a separate issue, and with more care and thought. Therefore, the new, temporary function `get_authors_rank.py` should not be used until further development.
- Considering the new function `get_author_stats`:
  - A new endpoint `/a/authorID/stats` is now open for requests.
  - Circular imports between `__init__.py` (which used to hold necessary definitions, including the API functions) and `get_author_stats.py` (which used some of the definitions in `__init__.py`), made it necessary to create a new module called `definitions.py`.
  - The flow of data, therefore, is as this:
    - `definitions.py` handles the `config.json` file and imports the `elsametric` package and the API function `get_institution_authors`. All necessary constants and variables for `elsaserver` to function are made available in this file.
    - `__init__.py` imports everything inside `definitions.py` and also all of the API functions.
    - The API functions (including `get_author_stats` import what they need from `__init__.py`. This does not cause any circular imports since the order of importing within `__init__.py` is carefully arranged.
    - The function `front_back_mapper` which used to reside in `__init__.py` was moved to the `helpers.py` module, to stay with other helper functions.